### PR TITLE
DTSPO-6108 - update disable script logic

### DIFF
--- a/scripts/disable-resource-locking.sh
+++ b/scripts/disable-resource-locking.sh
@@ -18,7 +18,7 @@ do
     echo "Disabling lock for resource group: $RG"
     for LOCK in $LOCKS;
     do
-      if grep -q "$RG/providers/Microsoft.Authorization" <<< "$LOCK"
+      if grep -q "/resourceGroups/$RG/providers/Microsoft.Authorization" <<< "$LOCK"
       then
       echo "Deleting resource group level lock $LOCK"
       az group lock delete --ids $LOCK


### PR DESCRIPTION
Added /resourceGroups to the grep logic just in case there was a resource and resourceGroup with the same name that could potentially confuse the script as is.
