### PR TITLE
Add DTS-SHAREDSERVICES-DEV to disable resource locks pipeline

### DIFF
--- a/pipelines/disable-resource-locks.yaml
+++ b/pipelines/disable-resource-locks.yaml
@@ -14,6 +14,7 @@ parameters:
     values:
     - 'DCD-CNP-DEV'
     - 'DCD-CNP-PROD'
+    - 'DTS-SHAREDSERVICES-DEV'
     - 'DTS-SHAREDSERVICES-STG'
     - 'DTS-SHAREDSERVICES-PROD'
     - 'HMCTS-HUB-PROD-INTSVC'


### PR DESCRIPTION
### Change description ###
I would like to be able to remove resource locks from my resource group in DTS-SHAREDSERVICES-DEV on a self-service basis


**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
