### PR TITLE
Exclude AKS network rgs

### DIFF
--- a/scripts/enable-resource-locking.sh
+++ b/scripts/enable-resource-locking.sh
@@ -25,6 +25,11 @@ exclusions=(
   ss-prod-01-aks-node-rg
   ss-stg-00-aks-node-rg
   ss-stg-01-aks-node-rg
+  cft-prod-network-rg
+  cft-aat-network-rg
+  cft-demo-network-rg
+  ss-stg-network-rg
+  ss-prod-network-rg
 )
 
 for rg in ${RG_LIST[@]}


### PR DESCRIPTION
It blocks new postgres flexible servers which is stupid