### PR TITLE
DTSPO-17088 - added managed-rg-fxateuu in exception group

### DIFF
--- a/scripts/enable-resource-locking.sh
+++ b/scripts/enable-resource-locking.sh
@@ -30,6 +30,7 @@ exclusions=(
   cft-demo-network-rg
   ss-stg-network-rg
   ss-prod-network-rg
+  managed-rg-fxateuu
 )
 
 RG_LIST_EXEMPT=$(az group list --query "[?tags.exemptFromAutoLock=='true'].name" -o tsv | sort -u )


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17088

### Change description ###

Added  managed-rg-fxateuu as exception because deny assignment blocking it to apply the resource lock.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

