### PR TITLE
DTSPO-17517 excludes bulk-scan-aks-rg from resources lock

### DIFF
--- a/scripts/enable-resource-locking.sh
+++ b/scripts/enable-resource-locking.sh
@@ -31,6 +31,7 @@ exclusions=(
   ss-stg-network-rg
   ss-prod-network-rg
   managed-rg-fxateuu
+  bulk-scan-aks-rg
 )
 
 RG_LIST_EXEMPT=$(az group list --query "[?tags.exemptFromAutoLock=='true'].name" -o tsv | sort -u )


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17517


### Change description ###

Exclude the resource group `bulk-scan-aks-rg` being automatically locked 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

